### PR TITLE
Separate Delegate from TextField to avoid conflict with BlocksKit

### DIFF
--- a/Classes/UITextFieldMask.h
+++ b/Classes/UITextFieldMask.h
@@ -22,34 +22,34 @@
  
  Example.h
  
-    @interface Example : UIView <UITextFieldDelegate>
-    
-    @property (nonatomic, strong) UITextFieldMask *textFieldMask;
+ @interface Example : UIView <UITextFieldDelegate>
  
-    - (BOOL)doSearch:(NSString *)text;
+ @property (nonatomic, strong) UITextFieldMask *textFieldMask;
  
-    @end
+ - (BOOL)doSearch:(NSString *)text;
+ 
+ @end
  
  Example.m
  
-    @implementation Example
+ @implementation Example
  
-    - (void)awakeFromNib
-    {
-        NSStringMask *mask = [NSStringMask maskWithPattern:@"(\\d+)"];
+ - (void)awakeFromNib
+ {
+ NSStringMask *mask = [NSStringMask maskWithPattern:@"(\\d+)"];
  
-        self.textFieldMask.mask = mask;
-        self.textFieldMask.delegate = self;
-    }
+ self.textFieldMask.mask = mask;
+ self.textFieldMask.delegate = self;
+ }
  
-    - (BOOL)textFieldShouldReturn:(UITextField *)textField
-    {
-        return [self doSearch:textField.text];
-    }
+ - (BOOL)textFieldShouldReturn:(UITextField *)textField
+ {
+ return [self doSearch:textField.text];
+ }
  
-    ...
+ ...
  
-    @end
+ @end
  
  The instance's methods that conforms to UITextFieldDelegate will always be called __before__ UITextFieldMask's methods and their results have preference. Therefore, if _Example_'s `textFieldShouldReturn:` return `NO`, UITextFieldMask will not evaluate the mask.
  

--- a/Classes/UITextFieldMaskDynamicDelegate.h
+++ b/Classes/UITextFieldMaskDynamicDelegate.h
@@ -1,0 +1,26 @@
+//
+//  UITextFieldMaskDelegate.h
+//  Pods
+//
+//  Created by Alessandro Nakamuta on 20/10/14.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+
+#import "NSStringMask.h"
+
+@interface UITextFieldMaskDynamicDelegate : NSObject <UITextFieldDelegate>
+
+#pragma mark - Properties
+/// @name Properties
+
+/** The mask to be applied to the text field.
+ */
+@property (nonatomic, strong) NSStringMask *mask;
+@property (nonatomic, strong) id<UITextFieldDelegate> realDelegate;
+
+
+@end

--- a/Classes/UITextFieldMaskDynamicDelegate.h
+++ b/Classes/UITextFieldMaskDynamicDelegate.h
@@ -20,7 +20,7 @@
 /** The mask to be applied to the text field.
  */
 @property (nonatomic, strong) NSStringMask *mask;
-@property (nonatomic, strong) id<UITextFieldDelegate> realDelegate;
+@property (nonatomic, weak) id<UITextFieldDelegate> realDelegate;
 
 
 @end

--- a/Classes/UITextFieldMaskDynamicDelegate.m
+++ b/Classes/UITextFieldMaskDynamicDelegate.m
@@ -1,0 +1,109 @@
+//
+//  UITextFieldMaskDelegate.m
+//  Pods
+//
+//  Created by Alessandro Nakamuta on 20/10/14.
+//
+//
+
+#import "UITextFieldMaskDynamicDelegate.h"
+
+@implementation UITextFieldMaskDynamicDelegate
+
+#pragma mark - UITextFieldDelegate
+
+- (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string
+{
+    if ([self.realDelegate respondsToSelector:@selector(textField:shouldChangeCharactersInRange:replacementString:)] &&
+        ! [self.realDelegate textField:textField shouldChangeCharactersInRange:range replacementString:string])
+    {
+        return NO;
+    }
+    
+    NSString *mutableString = [textField.text stringByReplacingCharactersInRange:range withString:string];
+    
+    NSString *clean = [self.mask validCharactersForString:mutableString];
+    
+    mutableString = [self.mask format:mutableString];
+    
+    NSRange newRange = NSMakeRange(0, 0);
+    
+    if (clean.length > 0)
+    {
+        newRange = [mutableString rangeOfString:[clean substringFromIndex:clean.length-1] options:NSBackwardsSearch];
+        if (newRange.location == NSNotFound)
+        {
+            newRange.location = mutableString.length;
+        }
+        else
+        {
+            newRange.location += newRange.length;
+        }
+        
+        newRange.length = 0;
+    }
+    
+    [textField setValue:[NSValue valueWithRange:newRange] forKey:@"selectionRange"];
+    textField.text = mutableString;
+    
+    return NO;
+}
+
+- (void)textFieldDidBeginEditing:(UITextField *)textField
+{
+    if ([self.realDelegate respondsToSelector:@selector(textFieldDidBeginEditing:)])
+    {
+        [self.realDelegate textFieldDidBeginEditing:textField];
+    }
+}
+
+- (void)textFieldDidEndEditing:(UITextField *)textField
+{
+    if ([self.realDelegate respondsToSelector:@selector(textFieldDidEndEditing:)])
+    {
+        [self.realDelegate textFieldDidEndEditing:textField];
+    }
+}
+
+- (BOOL)textFieldShouldBeginEditing:(UITextField *)textField
+{
+    if ([self.realDelegate respondsToSelector:@selector(textFieldShouldBeginEditing:)])
+    {
+        return [self.realDelegate textFieldShouldBeginEditing:textField];
+    }
+    
+    return YES;
+}
+
+- (BOOL)textFieldShouldClear:(UITextField *)textField
+{
+    if ([self.realDelegate respondsToSelector:@selector(textFieldShouldClear:)])
+    {
+        return [self.realDelegate textFieldShouldClear:textField];
+    }
+    
+    return YES;
+}
+
+- (BOOL)textFieldShouldEndEditing:(UITextField *)textField
+{
+    if ([self.realDelegate respondsToSelector:@selector(textFieldShouldEndEditing:)])
+    {
+        return [self.realDelegate textFieldShouldEndEditing:textField];
+    }
+    
+    return YES;
+}
+
+- (BOOL)textFieldShouldReturn:(UITextField *)textField
+{
+    if ([self.realDelegate respondsToSelector:@selector(textFieldShouldReturn:)])
+    {
+        textField.text = [self.mask validCharactersForString:textField.text];
+        return [self.realDelegate textFieldShouldReturn:textField];
+    }
+    
+    return YES;
+}
+
+@end

--- a/NSStringMask.xcodeproj/project.pbxproj
+++ b/NSStringMask.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 /* Begin PBXBuildFile section */
 		7209054117284FBF0091402D /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7209053F17284FBF0091402D /* InfoPlist.strings */; };
 		7209054417284FBF0091402D /* NSStringMaskTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7209054317284FBF0091402D /* NSStringMaskTests.m */; };
+		A1E88DE619F5A29500FFA8C3 /* UITextFieldMaskDynamicDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = A1E88DE519F5A29500FFA8C3 /* UITextFieldMaskDynamicDelegate.m */; };
 		F230991217346F870028F669 /* CompleteExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = F230991117346F870028F669 /* CompleteExtension.m */; };
 		F23B9FFC17344B21001957D5 /* UITextFieldMask.m in Sources */ = {isa = PBXBuildFile; fileRef = F23B9FFB17344B21001957D5 /* UITextFieldMask.m */; };
 		F24E5BA0173833F10006CA92 /* IncompleteExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = F24E5B9F173833F10006CA92 /* IncompleteExtension.m */; };
@@ -43,6 +44,8 @@
 		7209053E17284FBF0091402D /* NSStringMaskTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "NSStringMaskTests-Info.plist"; sourceTree = "<group>"; };
 		7209054017284FBF0091402D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		7209054317284FBF0091402D /* NSStringMaskTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSStringMaskTests.m; sourceTree = "<group>"; };
+		A1E88DE419F5A29500FFA8C3 /* UITextFieldMaskDynamicDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UITextFieldMaskDynamicDelegate.h; sourceTree = "<group>"; };
+		A1E88DE519F5A29500FFA8C3 /* UITextFieldMaskDynamicDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UITextFieldMaskDynamicDelegate.m; sourceTree = "<group>"; };
 		F230990E173460850028F669 /* UITextFieldMaskTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UITextFieldMaskTests.m; path = UITextFieldMask/UITextFieldMaskTests.m; sourceTree = "<group>"; };
 		F230991017346F870028F669 /* CompleteExtension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CompleteExtension.h; path = UITextFieldMask/CompleteExtension.h; sourceTree = "<group>"; };
 		F230991117346F870028F669 /* CompleteExtension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CompleteExtension.m; path = UITextFieldMask/CompleteExtension.m; sourceTree = "<group>"; };
@@ -168,6 +171,8 @@
 				F2E3992D172AF7DD007F4FC1 /* NSStringMask.m */,
 				F23B9FFA17344B21001957D5 /* UITextFieldMask.h */,
 				F23B9FFB17344B21001957D5 /* UITextFieldMask.m */,
+				A1E88DE419F5A29500FFA8C3 /* UITextFieldMaskDynamicDelegate.h */,
+				A1E88DE519F5A29500FFA8C3 /* UITextFieldMaskDynamicDelegate.m */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -201,7 +206,7 @@
 			name = NSStringMaskTests;
 			productName = NSStringMaskTests;
 			productReference = 7209053517284FBF0091402D /* NSStringMaskTests.octest */;
-			productType = "com.apple.product-type.bundle";
+			productType = "com.apple.product-type.bundle.ocunit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -281,6 +286,7 @@
 				F25F360E183BF2D8009D3F47 /* UITextFieldMaskTests.m in Sources */,
 				7209054417284FBF0091402D /* NSStringMaskTests.m in Sources */,
 				F23B9FFC17344B21001957D5 /* UITextFieldMask.m in Sources */,
+				A1E88DE619F5A29500FFA8C3 /* UITextFieldMaskDynamicDelegate.m in Sources */,
 				F230991217346F870028F669 /* CompleteExtension.m in Sources */,
 				F24E5BA0173833F10006CA92 /* IncompleteExtension.m in Sources */,
 			);


### PR DESCRIPTION
Create a separate object to avoid textField to delegate itself. It seems to break compatibility with BlocksKit.
