### PR TITLE
fix(classes): Cursor Selection Needs To Happen After Setting Text

### DIFF
--- a/Classes/UITextFieldMask.m
+++ b/Classes/UITextFieldMask.m
@@ -77,8 +77,8 @@
         newRange.length = 0;
     }
     
-    [textField setValue:[NSValue valueWithRange:newRange] forKey:@"selectionRange"];
     textField.text = mutableString;
+    [textField setValue:[NSValue valueWithRange:newRange] forKey:@"selectionRange"];
     
     return NO;
 }


### PR DESCRIPTION
Setting the text property on UITextField will set the cursor selection to the end of the input.
