### PR TITLE
Change (id) to (instancetype)

### DIFF
--- a/Classes/NSStringMask.h
+++ b/Classes/NSStringMask.h
@@ -55,7 +55,7 @@
  
  @return An instance or nil if regex is invalid.
  */
-+ (id)maskWithRegex:(NSRegularExpression *)regex;
++ (instancetype)maskWithRegex:(NSRegularExpression *)regex;
 
 /** Returns an NSStringMask instance set with the given _regex_ and _placeholder_.
  
@@ -66,7 +66,7 @@
  
  @return An instance or nil if regex is invalid.
  */
-+ (id)maskWithRegex:(NSRegularExpression *)regex placeholder:(NSString *)placeholder;
++ (instancetype)maskWithRegex:(NSRegularExpression *)regex placeholder:(NSString *)placeholder;
 
 /** Initiates the instance with a given _regex_.
  
@@ -76,7 +76,7 @@
  
  @return An instance or nil if regex is invalid.
  */
-- (id)initWithRegex:(NSRegularExpression *)regex;
+- (instancetype)initWithRegex:(NSRegularExpression *)regex;
 
 /** Initiates the instance with a given _regex_ and _placeholder_.
  
@@ -87,7 +87,7 @@
  
  @return An instance or nil if regex is invalid.
  */
-- (id)initWithRegex:(NSRegularExpression *)regex placeholder:(NSString *)placeholder;
+- (instancetype)initWithRegex:(NSRegularExpression *)regex placeholder:(NSString *)placeholder;
 
 /** Returns a NSStringMask instance set with the given _pattern_.
  
@@ -99,7 +99,7 @@
  
  @return An instance or nil if pattern is invalid.
  */
-+ (id)maskWithPattern:(NSString *)pattern;
++ (instancetype)maskWithPattern:(NSString *)pattern;
 
 /** Returns a NSStringMask instance set with the given _pattern_ and _placeholder_.
  
@@ -112,7 +112,7 @@
  
  @return An instance or nil if pattern is invalid.
  */
-+ (id)maskWithPattern:(NSString *)pattern placeholder:(NSString *)placeholder;
++ (instancetype)maskWithPattern:(NSString *)pattern placeholder:(NSString *)placeholder;
 
 /** Initiates the instance with a given _pattern_.
  
@@ -124,7 +124,7 @@
  
  @return An instance or nil if pattern is invalid.
  */
-- (id)initWithPattern:(NSString *)pattern;
+- (instancetype)initWithPattern:(NSString *)pattern;
 
 /** Initiates the instance with a given _pattern_ and _placeholder_.
  
@@ -137,7 +137,7 @@
  
  @return An instance or nil if pattern is invalid.
  */
-- (id)initWithPattern:(NSString *)pattern placeholder:(NSString *)placeholder;
+- (instancetype)initWithPattern:(NSString *)pattern placeholder:(NSString *)placeholder;
 
 #pragma mark - Class Methods
 /// @name Class Methods

--- a/Classes/NSStringMask.m
+++ b/Classes/NSStringMask.m
@@ -63,7 +63,7 @@
 @implementation NSStringMask
 
 // Initiates the instance with a given pattern.
-- (id)initWithPattern:(NSString *)pattern
+- (instancetype)initWithPattern:(NSString *)pattern
 {
     NSError *error = nil;
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern
@@ -75,7 +75,7 @@
 }
 
 // Initiates the instance with a given _pattern_ and _placeholder_.
-- (id)initWithPattern:(NSString *)pattern placeholder:(NSString *)placeholder
+- (instancetype)initWithPattern:(NSString *)pattern placeholder:(NSString *)placeholder
 {
     self = [self initWithPattern:pattern];
     if (self)
@@ -86,7 +86,7 @@
 }
 
 // Initiates the instance with a given NSRegularExpression.
-- (id)initWithRegex:(NSRegularExpression *)regex
+- (instancetype)initWithRegex:(NSRegularExpression *)regex
 {
     if (regex == nil || regex.numberOfCaptureGroups == 0) return nil;
     
@@ -101,7 +101,7 @@
 }
 
 // Initiates the instance with a given _regex_ and _placeholder_.
-- (id)initWithRegex:(NSRegularExpression *)regex placeholder:(NSString *)placeholder
+- (instancetype)initWithRegex:(NSRegularExpression *)regex placeholder:(NSString *)placeholder
 {
     self = [self initWithRegex:regex];
     if (self)
@@ -114,25 +114,25 @@
 #pragma mark - Class Initializers
 
 // Returns an NSStringMask instance set with the given NSRegularExpression.
-+ (id)maskWithRegex:(NSRegularExpression *)regex
++ (instancetype)maskWithRegex:(NSRegularExpression *)regex
 {
     return [[NSStringMask alloc] initWithRegex:regex];
 }
 
 // Returns an NSStringMask instance set with the given _regex_ and _placeholder_.
-+(id)maskWithRegex:(NSRegularExpression *)regex placeholder:(NSString *)placeholder
++ (instancetype)maskWithRegex:(NSRegularExpression *)regex placeholder:(NSString *)placeholder
 {
     return [[NSStringMask alloc] initWithRegex:regex placeholder:placeholder];
 }
 
 // Returns a NSStringMask instance set with the given pattern.
-+ (id)maskWithPattern:(NSString *)pattern
++ (instancetype)maskWithPattern:(NSString *)pattern
 {
     return [[NSStringMask alloc] initWithPattern:pattern];
 }
 
 // Returns a NSStringMask instance set with the given _pattern_ and _placeholder_.
-+(id)maskWithPattern:(NSString *)pattern placeholder:(NSString *)placeholder
++ (instancetype)maskWithPattern:(NSString *)pattern placeholder:(NSString *)placeholder
 {
     return [[NSStringMask alloc] initWithPattern:pattern placeholder:placeholder];
 }

--- a/Classes/UITextFieldMask.h
+++ b/Classes/UITextFieldMask.h
@@ -75,7 +75,7 @@
  @return An instance of UITextFieldMask
  @return nil if _mask_ is nil
  */
-- (id)initWithMask:(NSStringMask *)mask;
+- (instancetype)initWithMask:(NSStringMask *)mask;
 
 @end
 

--- a/Classes/UITextFieldMask.m
+++ b/Classes/UITextFieldMask.m
@@ -20,7 +20,7 @@
 @implementation UITextFieldMask
 
 // An adapter of UITextFieldDelegate to easily integrate with NSStringMask.
-- (id)initWithMask:(NSStringMask *)mask
+- (instancetype)initWithMask:(NSStringMask *)mask
 {
     self = [super init];
     if (self)


### PR DESCRIPTION
This library is exactly what I was looking for. Nice job. I noticed that most of the initializers returned `id` though instead of the [recommended](https://developer.apple.com/library/ios/releasenotes/ObjectiveC/ModernizationObjC/AdoptingModernObjective-C/AdoptingModernObjective-C.html) `instancetype`. This PR just changes that. Tests passed locally.